### PR TITLE
[bugfix] in compiler.rs

### DIFF
--- a/lib/austral_lib/src/compiler.rs
+++ b/lib/austral_lib/src/compiler.rs
@@ -231,7 +231,7 @@ fn build_expr<'c, 'b>(
                             None,
                             MemRefType::new(
                                 IntegerType::new(ctx, 8).into(),
-                                &[value.len() as u64],
+                                &[value.len() as i64],
                                 None,
                                 None,
                             ),
@@ -272,7 +272,7 @@ fn build_expr<'c, 'b>(
                         &format!("LiteralStr{literal_idx}"),
                         MemRefType::new(
                             IntegerType::new(ctx, 8).into(),
-                            &[value.len() as u64],
+                            &[value.len() as i64],
                             None,
                             None,
                         ),


### PR DESCRIPTION
Two times corrected this casting bug
```
   Compiling austral_lib v0.1.0 (/Users/kenarab/git/austral.rs/lib/austral_lib)
error[E0308]: mismatched types
   --> lib/austral_lib/src/compiler.rs:234:35
    |
234 | ...                   &[value.len() as u64],
    |                         ^^^^^^^^^^^^^^^^^^ expected `i64`, found `u64`
    |
help: you can convert a `u64` to an `i64` and panic if the converted value doesn't fit
    |
234 |                                 &[(value.len() as u64).try_into().unwrap()],
    |                                   +                  +++++++++++++++++++++
```